### PR TITLE
Fix FinalErrorHandler for error phase

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -140,9 +140,7 @@ func (s *Layer) Run(phase string, w http.ResponseWriter, r *http.Request, h http
 
 	stack := s.Pool[phase]
 	if stack == nil {
-		if phase != "error" {
-			h.ServeHTTP(w, r)
-		}
+		h.ServeHTTP(w, r)
 		return
 	}
 


### PR DESCRIPTION
### Expected behavior

When using a `Layer`, an unrecovered `panic` should cause the `FinalErrorHandler` to be use and return a 500 status code with the error message.
### Actual behavior

The `FinalErrorHandler` was never used if a `panic` occured. The `Run` function simply returned without calling `serveHTTP` (ref. https://github.com/vinci-proxy/layer/blob/master/layer.go#L143) and therefore simply swallows the panic. @h2non correct me if this was the expected behavior.
### Additional information

This PR should also increase code coverage.
