### PR TITLE
Remove coveralls token from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - go test -v -race -covermode=atomic -coverprofile=coverage.out
 
 after_success:
-  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - goveralls -coverprofile=coverage.out -service=travis-ci


### PR DESCRIPTION
### Expected behavior

Coveralls should run on Travis CI.
### Actual behavior

Due to the `$COVERALLS_TOKEN` not being set, goveralls test crash on travis for my repository and during PRs. Goveralls should not need the `repo-token` argument to be used when running on Travis (https://github.com/mattn/goveralls#github-integration).  
