### PR TITLE
feat(#10): parent layer single inheritance support

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -28,7 +28,7 @@ type MiddlewareHandlerFunc func(http.Handler) func(http.ResponseWriter, *http.Re
 //
 // For instance, you can register request and error handlers:
 //
-//   func (s *MyStruct) Register(mw layer.Pluggable) {
+//   func (s *MyStruct) Register(mw layer.Middleware) {
 //      mw.Use("request", s.requestHandler)
 //      mw.Use("error", s.errorHandler)
 //   }
@@ -36,7 +36,7 @@ type MiddlewareHandlerFunc func(http.Handler) func(http.ResponseWriter, *http.Re
 type Registrable interface {
 	// Register is designed to allow the plugin developers
 	// to attach multiple middleware layers passing the current middleware layer.
-	Register(Pluggable)
+	Register(Middleware)
 }
 
 // AdaptFunc adapts the given function polumorphic interface

--- a/layer.go
+++ b/layer.go
@@ -201,6 +201,6 @@ func (s *Layer) runRecoverError(rerr interface{}, w http.ResponseWriter, r *http
 	})
 
 	// Expose error via context. This may change in a future.
-	context.Set(r, "error", rerr)
+	context.Set(r, "vinxi.error", rerr)
 	s.Run("error", w, r, next)
 }

--- a/layer.go
+++ b/layer.go
@@ -10,7 +10,6 @@ import (
 const (
 	// ErrorPhase defines error middleware phase idenfitier.
 	ErrorPhase = "error"
-
 	// RequestPhase defines the default middleware phase for request.
 	RequestPhase = "request"
 )
@@ -39,12 +38,12 @@ type Runnable interface {
 type Pluggable interface {
 	// Use method is used to register a new middleware handler in the stack.
 	Use(phase string, handler ...interface{})
-
 	// UsePriority method is used to register a new middleware handler in a specific phase.
 	UsePriority(string, Priority, ...interface{})
-
 	// UseFinalHandler defines the middleware handler terminator
 	UseFinalHandler(handler http.Handler)
+	// SetParent allows hierarchical middleware.
+	SetParent(Middleware)
 }
 
 // Middleware especifies the required interface that must be
@@ -56,8 +55,6 @@ type Middleware interface {
 	Pluggable
 	// Flush flushes the middleware handlers pool.
 	Flush()
-	// SetParent allows hierarchical middleware.
-	SetParent(Middleware)
 }
 
 // Pool represents the phase-specific stack to store middleware functions.
@@ -68,10 +65,8 @@ type Pool map[string]*Stack
 type Layer struct {
 	// finalHandler stores the final middleware chain handler.
 	finalHandler http.Handler
-
 	// parent stores the parent middleware layer to use. Use SetParent(parent).
 	parent Middleware
-
 	// Pool stores the phase-specific middleware handlers stack.
 	Pool Pool
 }

--- a/layer.go
+++ b/layer.go
@@ -69,6 +69,9 @@ type Layer struct {
 	// finalHandler stores the final middleware chain handler.
 	finalHandler http.Handler
 
+	// parent stores the parent middleware layer to use. Use SetParent(parent).
+	parent Middleware
+
 	// Pool stores the phase-specific middleware handlers stack.
 	Pool Pool
 }
@@ -98,6 +101,12 @@ func (s *Layer) UsePriority(phase string, priority Priority, handler ...interfac
 // or error (e.g: cannot route the request).
 func (s *Layer) UseFinalHandler(fn http.Handler) {
 	s.finalHandler = fn
+}
+
+// SetParent sets a new middleware layer as parent layer,
+// allowing to trigger ancestors layer from the current one.
+func (s *Layer) SetParent(parent Middleware) {
+	s.parent = parent
 }
 
 // use is used internally to register one or multiple middleware handlers
@@ -133,7 +142,7 @@ func register(layer *Layer, stack *Stack, priority Priority, handler interface{}
 }
 
 // Run triggers the middleware call chain for the given phase.
-// In case of panic, it will be recovered transparently and trigger the error middleware chain.
+// In case of panic, it will be recovered transparently and trigger the error middleware chain.ç
 func (s *Layer) Run(phase string, w http.ResponseWriter, r *http.Request, h http.Handler) {
 	// In case of panic we want to handle it accordingly
 	defer func() {
@@ -141,11 +150,26 @@ func (s *Layer) Run(phase string, w http.ResponseWriter, r *http.Request, h http
 			return
 		}
 		if re := recover(); re != nil {
-			context.Set(r, "error", re) // Expose error via context. This may change in a future.
-			s.Run("error", w, r, FinalErrorHandler)
+			s.runRecoverError(re, w, r)
 		}
 	}()
 
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.run(phase, w, r, h)
+	})
+
+	// Run parent layer for the given phase, if present
+	if s.parent != nil && phase != "error" {
+		s.parent.Run(phase, w, r, next)
+		return
+	}
+
+	// Otherwise run the current layer
+	next.ServeHTTP(w, r)
+}
+
+// run runs the current layer middleware chain for the given phase.
+func (s *Layer) run(phase string, w http.ResponseWriter, r *http.Request, h http.Handler) {
 	// Use default final handler if no one is passed
 	if h == nil {
 		h = s.finalHandler
@@ -164,6 +188,24 @@ func (s *Layer) Run(phase string, w http.ResponseWriter, r *http.Request, h http
 		h = queue[i](h)
 	}
 
-	// Trigger the first handler
+	// Trigger the first middleware handler
 	h.ServeHTTP(w, r)
+}
+
+// runRecoverError runs the current layer error phase middleware chain
+// triggering the parent layer if necessary.
+func (s *Layer) runRecoverError(rerr interface{}, w http.ResponseWriter, r *http.Request) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If no parent, run default the final handler
+		if s.parent == nil {
+			FinalErrorHandler.ServeHTTP(w, r)
+			return
+		}
+		// If parent layer, trigger it
+		s.parent.Run("error", w, r, FinalErrorHandler)
+	})
+
+	// Expose error via context. This may change in a future.
+	context.Set(r, "error", rerr)
+	s.Run("error", w, r, next)
 }


### PR DESCRIPTION
Layer inheritance support is done. The layer will behave like described bellow:

```
When call Run(phase):
  If layer has a parent layer and phase is not error:
     Trigger first layer.parent.Run(phase)
     Then trigger layer.Run(phase)
  Else case if the parent layer is not present
      Trigger layer.Run(phase) as usual
```

There's an special behavior for `error` phase, which handles panics. As I described in issue #10, instead of generalization and parent prioritization, for error it's better to run it the more scope specific logic first, and then the generic one, so the algorithm will behave like this in case of error.

```
When call Run(phase) and a panic happens:
  Run layer.Run(error) triggering layer scope error handlers
  Then if the final handler is reached
     If has parent layer present
        Run layer.parent.Run(error)
        If final handler is reached, run it.
     Else
        Trigger the default final error handler 
```
